### PR TITLE
Make the schema compatible with Postgres

### DIFF
--- a/server/helpers/database/schema.sql
+++ b/server/helpers/database/schema.sql
@@ -9,13 +9,13 @@ CREATE TABLE messages (
   payload JSON,
   sig VARCHAR(256) NOT NULL,
   metadata JSON,
-  PRIMARY KEY (`id`),
-  KEY address (address),
-  KEY version (version),
-  KEY timestamp (timestamp),
-  KEY space (space),
-  KEY token (token),
-  KEY type (type)
+  PRIMARY KEY (id),
+  INDEX address (address),
+  INDEX version (version),
+  INDEX timestamp (timestamp),
+  INDEX space (space),
+  INDEX token (token),
+  INDEX type (type)
 );
 
 CREATE TABLE hubs (
@@ -23,7 +23,7 @@ CREATE TABLE hubs (
   address VARCHAR(64),
   is_self INT DEFAULT 0,
   is_active INT DEFAULT 1,
-  PRIMARY KEY (`host`),
-  KEY address (address),
-  KEY is_self (is_self)
+  PRIMARY KEY (host),
+  INDEX address (address),
+  INDEX is_self (is_self)
 );


### PR DESCRIPTION
Changes proposed in this pull request:
- Using `INDEX` keyword to create the column indexes.
- Removed back-tic ` `` ` to solve SQL error in Postgres (the column names are always created in lower case).

The same schema.sql can be used for MySQL and Postgres - tested both.  
